### PR TITLE
Input manager

### DIFF
--- a/src/components/editor/controllers/input-manager.tsx
+++ b/src/components/editor/controllers/input-manager.tsx
@@ -1,6 +1,8 @@
 import { BaseNode } from "~/components/nodes/base-node";
 import { NodeSlot } from "~/components/nodes/slot/node-slot";
 import { ComponentEventHandler } from "../tools/base-tool";
+import { createSignal } from "solid-js";
+import { createStore, SetStoreFunction } from "solid-js/store";
 
 export enum MouseButtons {
     NONE = 0,
@@ -27,41 +29,39 @@ export class KeybindMap {
     private _mouse_buttons: MouseButtons[];
     private _keys: string[];
     private _modifiers: KeyModifiers[];
-    public active: boolean = false;
+    private _active: () => boolean;
+    private _set_active: (v: boolean) => void;
 
     constructor(binds: KeybindMapBinds) {
+        const [active, setActive] = createSignal(false);
+        this._active = active;
+        this._set_active = setActive;
+        
         this._mouse_buttons = binds.mouse_buttons == null ? [] : binds.mouse_buttons;
         this._keys = binds.keys == null ? [] : binds.keys;
         this._modifiers = binds.modifiers == null ? [] : binds.modifiers;
     }
 
+    get active() { return this._active(); }
+    set active(value: boolean) { this._set_active(value); }
+
     get mouse_buttons() { return this._mouse_buttons; }
     get keys() { return this._keys; }
     get modifiers() { return this._modifiers; }
 
-    public change_active(_mb_states: Map<MouseButtons, boolean>, _key_states: Map<string, boolean>, _modifier_states: Map<KeyModifiers, boolean>) {
-        let keybind_states: boolean[] = [];
+    public update_active(keys: Record<string, boolean>, mouse_buttons: Record<number, boolean>, modifiers: Record<number, boolean>): boolean {
+        const keys_active = this._keys.length > 0 ? this._keys.every(k => !!keys[k]) : true;
+        const mb_active = this._mouse_buttons.length > 0 ? this._mouse_buttons.every(m => !!mouse_buttons[m]) : true;
+        const mod_active = this._modifiers.length > 0 ? this._modifiers.every(mod => !!modifiers[mod]) : true;
+
+        const has_any_bind = this._keys.length > 0 || this._mouse_buttons.length > 0 || this._modifiers.length > 0;
         
-        this._mouse_buttons.forEach(code => {
-            const state = _mb_states.get(code)
-            keybind_states = [...keybind_states, state == undefined ? false : state]
-        });
-        this._keys.forEach(code => {
-            const state = _key_states.get(code)
-            keybind_states = [...keybind_states, state == undefined ? false : state]
-        });
-        this._modifiers.forEach(code => {
-            const state = _modifier_states.get(code)
-            keybind_states = [...keybind_states, state == undefined ? false : state]
-        });
+        const is_now_active = has_any_bind && keys_active && mb_active && mod_active;
 
-        if (keybind_states.includes(false)) {
-            this.active = false;
-            return false;
+        if (this.active !== is_now_active) {
+            this.active = is_now_active;
         }
-
-        this.active = true;
-        return true;
+        return is_now_active;
     }
 
     public set_mouse_buttons(buttons: MouseButtons[]) {
@@ -100,15 +100,9 @@ export class Keybind {
     }
 
     public is_active(): boolean {
-        let is_active: boolean = false;
-        this.maps.forEach(map => {
-            if (map.active) {
-                is_active = true;
-                return;
-            }
-        });
+        const active = this.maps.some(map => map.active)
 
-        return is_active;
+        return active;
     }
 }
 
@@ -120,37 +114,68 @@ export interface KeyEventData {
 export class KeyEventManager implements ComponentEventHandler {
     keybinds: Map<Keybind, (data: KeyEventData) => void>;
     
-    _mouse_button_state: Map<MouseButtons, boolean>;
-    _key_state: Map<string, boolean>;
-    _modifier_state: Map<KeyModifiers, boolean>;
+    private _key_state: { [key: string]: boolean};
+    private _set_keys: SetStoreFunction<{[key: string]: boolean}>;
+
+    private _mouse_button_state: { [mouse_button: number]: boolean};
+    private _set_mouse_button: SetStoreFunction<{[key: number]: boolean}>;;
+
+    private _modifier_state: { [modifier: number]: boolean};
+    private _set_modifier: SetStoreFunction<{[key: number]: boolean}>;;
 
     constructor() {
-        this.keybinds = new Map();
+        const [keys, setKeys]  = createStore<Record<string, boolean>>({});
+        this._key_state = keys;
+        this._set_keys = setKeys;
 
-        this._mouse_button_state = new Map();
-        this._key_state = new Map();
-        this._modifier_state = new Map();
+        const [mouse_button, setMouseButton] = createStore<Record<number, boolean>>({});
+        this._mouse_button_state = mouse_button;
+        this._set_mouse_button = setMouseButton;
+
+        const [modifierState, setModifier] = createStore<Record<number, boolean>>({
+            [KeyModifiers.ALT]: false,
+            [KeyModifiers.CTRL]: false,
+            [KeyModifiers.SHIFT]: false
+        });
+        this._modifier_state = modifierState;
+        this._set_modifier = setModifier;
+
+        this.keybinds = new Map();
     }
 
     public set_keybind_handler(keybind: Keybind, handler: (data: KeyEventData) => void) {
         this.keybinds.set(keybind, handler);
     }
 
+    public get_keybind_state(keybind_name: string): boolean {
+        const keybind = Array.from(
+            this.keybinds.keys()).find( 
+                k => k.keybind_name === keybind_name
+        );
+        
+        const active = keybind ? keybind.maps.some(map => map.active) : false;
+        return active;
+    }
+
+
     protected update_modifier_states(event: KeyboardEvent | MouseEvent) {
-        this._modifier_state.set(KeyModifiers.ALT, event.altKey);
-        this._modifier_state.set(KeyModifiers.CTRL, event.ctrlKey);
-        this._modifier_state.set(KeyModifiers.SHIFT, event.shiftKey);
+        this._set_modifier({
+            [KeyModifiers.ALT]: event.altKey,
+            [KeyModifiers.CTRL]: event.ctrlKey,
+            [KeyModifiers.SHIFT]: event.shiftKey
+        });
     }
 
     protected handle_keybinds(data: KeyEventData) {
         this.keybinds.forEach((handler, keybind) => {
             keybind.maps.forEach(map => {
-                map.change_active(
-                    this._mouse_button_state, 
+                map.update_active(
                     this._key_state, 
+                    this._mouse_button_state, 
                     this._modifier_state
                 );
             });
+
             if (keybind.is_active()) {
                 handler(data);
             }
@@ -159,21 +184,21 @@ export class KeyEventManager implements ComponentEventHandler {
 
     onKeyDown(e: KeyboardEvent): void {
         this.update_modifier_states(e);
-        this._key_state.set(e.code, true);
+        this._set_keys(e.code, true);
 
         this.handle_keybinds({event: e})
     }
     
     onKeyUp(e: KeyboardEvent): void {
         this.update_modifier_states(e);
-        this._key_state.set(e.code, false);
+        this._set_keys(e.code, false);
 
         this.handle_keybinds({event: e})
     }
     
     onWheel(e: WheelEvent): void {
         this.update_modifier_states(e);
-        this._mouse_button_state.set(MouseButtons.SCROLL, true);
+        this._set_mouse_button(MouseButtons.SCROLL, true);
     
         this.handle_keybinds({event: e})
     }
@@ -181,18 +206,18 @@ export class KeyEventManager implements ComponentEventHandler {
     onPointerDown(e: PointerEvent): void {
         this.update_modifier_states(e);
         MBUTTON_CODES.forEach(button_code => {
-            this._mouse_button_state.set(button_code, false);
+            this._set_mouse_button(button_code, (e.buttons & button_code) !== 0);
         })
-
-        this._mouse_button_state.set(e.buttons, true);
+        
         this.handle_keybinds({event: e})
     }
 
     onPointerUp(e: PointerEvent): void {
         this.update_modifier_states(e);
         MBUTTON_CODES.forEach(button_code => {
-            this._mouse_button_state.set(button_code, false);
+            this._set_mouse_button(button_code, (e.buttons & button_code) !== 0);
         })
+
         this.handle_keybinds({event: e})
     }
 

--- a/src/components/editor/controllers/input-manager.tsx
+++ b/src/components/editor/controllers/input-manager.tsx
@@ -6,8 +6,12 @@ import { createStore, SetStoreFunction } from "solid-js/store";
 
 // TODO: Change this to be an Events enum
 // then create a set_event_handler function on KeyEventManager
-export enum OtherStates {
-    POINTER_MOVING
+export enum InputEvents {
+    POINTER_MOVING,
+    CLICK_ON_NODE,
+    CLICK_ON_NODE_SLOT,
+    HOVER_NODE,
+    HOVER_SLOT
 }
 
 export enum MouseButtons {
@@ -26,14 +30,12 @@ export enum KeyModifiers {
 }
 
 export interface KeybindMapBinds {
-    other_states?: OtherStates[], 
     mouse_buttons?: MouseButtons[], 
     keys?: string[], 
     modifiers?: KeyModifiers[]
 }
 
 export class KeybindMap {
-    private _other_states: OtherStates[];
     private _mouse_buttons: MouseButtons[];
     private _keys: string[];
     private _modifiers: KeyModifiers[];
@@ -46,7 +48,6 @@ export class KeybindMap {
         this._set_active = setActive;
         
         this._mouse_buttons = binds.mouse_buttons == null ? [] : binds.mouse_buttons;
-        this._other_states = binds.other_states == null ? [] : binds.other_states;
         this._keys = binds.keys == null ? [] : binds.keys;
         this._modifiers = binds.modifiers == null ? [] : binds.modifiers;
     }
@@ -58,14 +59,13 @@ export class KeybindMap {
     get keys() { return this._keys; }
     get modifiers() { return this._modifiers; }
 
-    public update_active(keys: Record<string, boolean>, mouse_buttons: Record<number, boolean>, modifiers: Record<number, boolean>, other_states: Record<number, boolean>): boolean {
+    public update_active(keys: Record<string, boolean>, mouse_buttons: Record<number, boolean>, modifiers: Record<number, boolean>): boolean {
         const keys_active = this._keys.length > 0 ? this._keys.every(k => !!keys[k]) : true;
         const mb_active = this._mouse_buttons.length > 0 ? this._mouse_buttons.every(m => !!mouse_buttons[m]) : true;
         const mod_active = this._modifiers.length > 0 ? this._modifiers.every(mod => !!modifiers[mod]) : true;
-        const other_states_active = this._other_states.length > 0 ? this._other_states.every(state => !!other_states[state]) : true;
 
-        const has_any_bind = this._other_states.length > 0 || this._keys.length > 0 || this._mouse_buttons.length > 0 || this._modifiers.length > 0;
-        const is_now_active = has_any_bind && keys_active && mb_active && mod_active && other_states_active;
+        const has_any_bind = this._keys.length > 0 || this._mouse_buttons.length > 0 || this._modifiers.length > 0;
+        const is_now_active = has_any_bind && keys_active && mb_active && mod_active;
 
         if (this.active !== is_now_active) {
             this.active = is_now_active;
@@ -114,9 +114,26 @@ export class Keybind {
     }
 }
 
-
 export interface KeyEventData {
     event: UIEvent
+}
+
+export interface EventData {
+    event?: UIEvent
+    node?: BaseNode,
+    slot?: NodeSlot
+}
+
+export class EventHandler {
+    name: string;
+    private func: (event_data: EventData) => void;
+
+    constructor(handler_name: string, handler_func: (event_data: EventData) => void) {
+        this.name = handler_name;
+        this.func = handler_func;
+    }
+
+    get handler() { return this.func; }
 }
 
 export interface HandlersInterface {
@@ -139,12 +156,10 @@ class KeyHandlers {
 
 export class KeyEventManager implements ComponentEventHandler {
     keybinds: Map<Keybind, KeyHandlers>;
+    event_handlers: Map<InputEvents, Array<EventHandler>>;
     
     private _key_state: { [key: string]: boolean};
     private _set_keys: SetStoreFunction<{[key: string]: boolean}>;
-
-    private _other_states: { [key: string]: boolean};
-    private _set_other_states: SetStoreFunction<{[key: string]: boolean}>;
 
     private _mouse_button_state: { [mouse_button: number]: boolean};
     private _set_mouse_button: SetStoreFunction<{[key: number]: boolean}>;;
@@ -158,10 +173,8 @@ export class KeyEventManager implements ComponentEventHandler {
         this._set_keys = setKeys;
 
         const [otherStates, setOtherStates]  = createStore<Record<string, boolean>>({
-            [OtherStates.POINTER_MOVING]: false
+            [InputEvents.POINTER_MOVING]: false
         });
-        this._other_states = otherStates;
-        this._set_other_states = setOtherStates;
 
         const [mouse_button, setMouseButton] = createStore<Record<number, boolean>>({});
         this._mouse_button_state = mouse_button;
@@ -176,6 +189,21 @@ export class KeyEventManager implements ComponentEventHandler {
         this._set_modifier = setModifier;
 
         this.keybinds = new Map();
+        this.event_handlers = new Map();
+
+        const event_keys = Object.values(InputEvents).filter(value => typeof value === "number");
+        event_keys.forEach(key => {
+            this.event_handlers.set(key, []);
+        });
+    }
+    
+
+    public set_event_handler(target_event: InputEvents, handler: EventHandler) {
+        const event_handlers = this.event_handlers.get(target_event)
+        if (event_handlers == null) {
+            return;
+        }
+        event_handlers.push(handler);
     }
 
     public set_keybind_handler(keybind: Keybind, handlers: HandlersInterface) {
@@ -205,14 +233,6 @@ export class KeyEventManager implements ComponentEventHandler {
         });
     }
 
-    protected update_other_states(event: PointerEvent) {
-        if (event.movementX != 0 || event.movementY != 0) {
-            this._set_other_states(OtherStates.POINTER_MOVING, true)
-        } else {
-            this._set_other_states(OtherStates.POINTER_MOVING, false)
-        }
-    }
-
     protected handle_keybinds(data: KeyEventData) {
         this.keybinds.forEach((handler, keybind) => {
             const previous_state = keybind.is_active();
@@ -220,8 +240,7 @@ export class KeyEventManager implements ComponentEventHandler {
                 map.update_active(
                     this._key_state, 
                     this._mouse_button_state, 
-                    this._modifier_state,
-                    this._other_states
+                    this._modifier_state
                 );
             });
 
@@ -261,12 +280,17 @@ export class KeyEventManager implements ComponentEventHandler {
     }
     
     onPointerMove(e: PointerEvent): void {
-        this.update_modifier_states(e);
+        const handlers = this.event_handlers.get(InputEvents.POINTER_MOVING)
+        handlers?.forEach(handler => {
+            handler.handler({event: e});
+        });
+        // this.update_modifier_states(e);
+
         // this.update_other_states(e);
 
-        this._set_other_states(OtherStates.POINTER_MOVING, true)
-        this.handle_keybinds({event: e})
-        this._set_other_states(OtherStates.POINTER_MOVING, false)
+        // this._set_other_states(Events.POINTER_MOVING, true)
+        // this.handle_keybinds({event: e})
+        // this._set_other_states(Events.POINTER_MOVING, false)
     }
 
     onPointerDown(e: PointerEvent): void {
@@ -288,10 +312,23 @@ export class KeyEventManager implements ComponentEventHandler {
     }
 
     onClickOnNode(node: BaseNode): void {
-        throw new Error("Method not implemented.");
+        const handlers = this.event_handlers.get(InputEvents.CLICK_ON_NODE)
+        handlers?.forEach(handler => {
+            handler.handler({node: node});
+        });
     }
 
     onClickOnNodeSlot(slot: NodeSlot): void {
-        throw new Error("Method not implemented.");
+        const handlers = this.event_handlers.get(InputEvents.CLICK_ON_NODE_SLOT)
+        handlers?.forEach(handler => {
+            handler.handler({slot: slot});
+        });
+    }
+
+    onHoverNode(node: BaseNode): void {
+        
+    }
+    onHoverSlot(slot: NodeSlot): void {
+        
     }
 }

--- a/src/components/editor/controllers/input-manager.tsx
+++ b/src/components/editor/controllers/input-manager.tsx
@@ -1,0 +1,206 @@
+import { BaseNode } from "~/components/nodes/base-node";
+import { NodeSlot } from "~/components/nodes/slot/node-slot";
+import { ComponentEventHandler } from "../tools/base-tool";
+
+export enum MouseButtons {
+    NONE = 0,
+    LEFT = 1,
+    RIGHT = 2,
+    MIDDLE = 4,
+    SCROLL
+}
+const MBUTTON_CODES = Object.values(MouseButtons).filter((item): item is number => typeof item === 'number');
+
+export enum KeyModifiers {
+    CTRL,
+    SHIFT,
+    ALT
+}
+
+export interface KeybindMapBinds {
+    mouse_buttons?: MouseButtons[], 
+    keys?: string[], 
+    modifiers?: KeyModifiers[]
+}
+
+export class KeybindMap {
+    private _mouse_buttons: MouseButtons[];
+    private _keys: string[];
+    private _modifiers: KeyModifiers[];
+    public active: boolean = false;
+
+    constructor(binds: KeybindMapBinds) {
+        this._mouse_buttons = binds.mouse_buttons == null ? [] : binds.mouse_buttons;
+        this._keys = binds.keys == null ? [] : binds.keys;
+        this._modifiers = binds.modifiers == null ? [] : binds.modifiers;
+    }
+
+    get mouse_buttons() { return this._mouse_buttons; }
+    get keys() { return this._keys; }
+    get modifiers() { return this._modifiers; }
+
+    public change_active(_mb_states: Map<MouseButtons, boolean>, _key_states: Map<string, boolean>, _modifier_states: Map<KeyModifiers, boolean>) {
+        let keybind_states: boolean[] = [];
+        
+        this._mouse_buttons.forEach(code => {
+            const state = _mb_states.get(code)
+            keybind_states = [...keybind_states, state == undefined ? false : state]
+        });
+        this._keys.forEach(code => {
+            const state = _key_states.get(code)
+            keybind_states = [...keybind_states, state == undefined ? false : state]
+        });
+        this._modifiers.forEach(code => {
+            const state = _modifier_states.get(code)
+            keybind_states = [...keybind_states, state == undefined ? false : state]
+        });
+
+        if (keybind_states.includes(false)) {
+            this.active = false;
+            return false;
+        }
+
+        this.active = true;
+        return true;
+    }
+
+    public set_mouse_buttons(buttons: MouseButtons[]) {
+        this._mouse_buttons = buttons;
+    }
+
+    public set_keys(keys: string[]) {
+        this._keys = keys;
+    }
+
+    public set_modifiers(modifiers: KeyModifiers[]) {
+        this._modifiers = modifiers;
+    }
+}
+
+export class Keybind {
+    keybind_name: string;
+    maps: KeybindMap[];
+
+    constructor(name: string, maps: KeybindMap[]) {
+        this.keybind_name = name;
+        this.maps = maps;
+    }
+
+    public add_map(map: KeybindMap) {
+        if (this.maps.includes(map)) {
+            return;
+        }
+        this.maps = [...this.maps, map];
+    }
+
+    public remove_map(map: KeybindMap) {
+        this.maps = this.maps.filter((_map: KeybindMap) => {
+            return _map !== map;
+        })
+    }
+
+    public is_active(): boolean {
+        let is_active: boolean = false;
+        this.maps.forEach(map => {
+            if (map.active) {
+                is_active = true;
+                return;
+            }
+        });
+
+        return is_active;
+    }
+}
+
+
+export interface KeyEventData {
+    event: UIEvent
+}
+
+export class KeyEventManager implements ComponentEventHandler {
+    keybinds: Map<Keybind, (data: KeyEventData) => void>;
+    
+    _mouse_button_state: Map<MouseButtons, boolean>;
+    _key_state: Map<string, boolean>;
+    _modifier_state: Map<KeyModifiers, boolean>;
+
+    constructor() {
+        this.keybinds = new Map();
+
+        this._mouse_button_state = new Map();
+        this._key_state = new Map();
+        this._modifier_state = new Map();
+    }
+
+    public set_keybind_handler(keybind: Keybind, handler: (data: KeyEventData) => void) {
+        this.keybinds.set(keybind, handler);
+    }
+
+    protected update_modifier_states(event: KeyboardEvent | MouseEvent) {
+        this._modifier_state.set(KeyModifiers.ALT, event.altKey);
+        this._modifier_state.set(KeyModifiers.CTRL, event.ctrlKey);
+        this._modifier_state.set(KeyModifiers.SHIFT, event.shiftKey);
+    }
+
+    protected handle_keybinds(data: KeyEventData) {
+        this.keybinds.forEach((handler, keybind) => {
+            keybind.maps.forEach(map => {
+                map.change_active(
+                    this._mouse_button_state, 
+                    this._key_state, 
+                    this._modifier_state
+                );
+            });
+            if (keybind.is_active()) {
+                handler(data);
+            }
+        });
+    }
+
+    onKeyDown(e: KeyboardEvent): void {
+        this.update_modifier_states(e);
+        this._key_state.set(e.code, true);
+
+        this.handle_keybinds({event: e})
+    }
+    
+    onKeyUp(e: KeyboardEvent): void {
+        this.update_modifier_states(e);
+        this._key_state.set(e.code, false);
+
+        this.handle_keybinds({event: e})
+    }
+    
+    onWheel(e: WheelEvent): void {
+        this.update_modifier_states(e);
+        this._mouse_button_state.set(MouseButtons.SCROLL, true);
+    
+        this.handle_keybinds({event: e})
+    }
+    
+    onPointerDown(e: PointerEvent): void {
+        this.update_modifier_states(e);
+        MBUTTON_CODES.forEach(button_code => {
+            this._mouse_button_state.set(button_code, false);
+        })
+
+        this._mouse_button_state.set(e.buttons, true);
+        this.handle_keybinds({event: e})
+    }
+
+    onPointerUp(e: PointerEvent): void {
+        this.update_modifier_states(e);
+        MBUTTON_CODES.forEach(button_code => {
+            this._mouse_button_state.set(button_code, false);
+        })
+        this.handle_keybinds({event: e})
+    }
+
+    onClickOnNode(node: BaseNode): void {
+        throw new Error("Method not implemented.");
+    }
+
+    onClickOnNodeSlot(slot: NodeSlot): void {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/src/components/editor/controllers/input-manager.tsx
+++ b/src/components/editor/controllers/input-manager.tsx
@@ -4,6 +4,12 @@ import { ComponentEventHandler } from "../tools/base-tool";
 import { createSignal } from "solid-js";
 import { createStore, SetStoreFunction } from "solid-js/store";
 
+// TODO: Change this to be an Events enum
+// then create a set_event_handler function on KeyEventManager
+export enum OtherStates {
+    POINTER_MOVING
+}
+
 export enum MouseButtons {
     NONE = 0,
     LEFT = 1,
@@ -20,12 +26,14 @@ export enum KeyModifiers {
 }
 
 export interface KeybindMapBinds {
+    other_states?: OtherStates[], 
     mouse_buttons?: MouseButtons[], 
     keys?: string[], 
     modifiers?: KeyModifiers[]
 }
 
 export class KeybindMap {
+    private _other_states: OtherStates[];
     private _mouse_buttons: MouseButtons[];
     private _keys: string[];
     private _modifiers: KeyModifiers[];
@@ -38,6 +46,7 @@ export class KeybindMap {
         this._set_active = setActive;
         
         this._mouse_buttons = binds.mouse_buttons == null ? [] : binds.mouse_buttons;
+        this._other_states = binds.other_states == null ? [] : binds.other_states;
         this._keys = binds.keys == null ? [] : binds.keys;
         this._modifiers = binds.modifiers == null ? [] : binds.modifiers;
     }
@@ -49,14 +58,14 @@ export class KeybindMap {
     get keys() { return this._keys; }
     get modifiers() { return this._modifiers; }
 
-    public update_active(keys: Record<string, boolean>, mouse_buttons: Record<number, boolean>, modifiers: Record<number, boolean>): boolean {
+    public update_active(keys: Record<string, boolean>, mouse_buttons: Record<number, boolean>, modifiers: Record<number, boolean>, other_states: Record<number, boolean>): boolean {
         const keys_active = this._keys.length > 0 ? this._keys.every(k => !!keys[k]) : true;
         const mb_active = this._mouse_buttons.length > 0 ? this._mouse_buttons.every(m => !!mouse_buttons[m]) : true;
         const mod_active = this._modifiers.length > 0 ? this._modifiers.every(mod => !!modifiers[mod]) : true;
+        const other_states_active = this._other_states.length > 0 ? this._other_states.every(state => !!other_states[state]) : true;
 
-        const has_any_bind = this._keys.length > 0 || this._mouse_buttons.length > 0 || this._modifiers.length > 0;
-        
-        const is_now_active = has_any_bind && keys_active && mb_active && mod_active;
+        const has_any_bind = this._other_states.length > 0 || this._keys.length > 0 || this._mouse_buttons.length > 0 || this._modifiers.length > 0;
+        const is_now_active = has_any_bind && keys_active && mb_active && mod_active && other_states_active;
 
         if (this.active !== is_now_active) {
             this.active = is_now_active;
@@ -101,7 +110,6 @@ export class Keybind {
 
     public is_active(): boolean {
         const active = this.maps.some(map => map.active)
-
         return active;
     }
 }
@@ -111,11 +119,32 @@ export interface KeyEventData {
     event: UIEvent
 }
 
+export interface HandlersInterface {
+    just_activated?: (data: KeyEventData) => void;
+    while_active?: (data: KeyEventData) => void;
+    cleanup?: (data: KeyEventData) => void;
+}
+
+class KeyHandlers {
+    just_activated_handler: (data: KeyEventData) => void;
+    while_active_handler: (data: KeyEventData) => void;
+    just_deactivated_handler: (data: KeyEventData) => void;
+
+    constructor(just_activated: (data: KeyEventData) => void, while_active: (data: KeyEventData) => void, just_deactivated: (data: KeyEventData) => void) {
+        this.just_activated_handler = just_activated;
+        this.while_active_handler = while_active;
+        this.just_deactivated_handler = just_deactivated;
+    }
+}
+
 export class KeyEventManager implements ComponentEventHandler {
-    keybinds: Map<Keybind, (data: KeyEventData) => void>;
+    keybinds: Map<Keybind, KeyHandlers>;
     
     private _key_state: { [key: string]: boolean};
     private _set_keys: SetStoreFunction<{[key: string]: boolean}>;
+
+    private _other_states: { [key: string]: boolean};
+    private _set_other_states: SetStoreFunction<{[key: string]: boolean}>;
 
     private _mouse_button_state: { [mouse_button: number]: boolean};
     private _set_mouse_button: SetStoreFunction<{[key: number]: boolean}>;;
@@ -127,6 +156,12 @@ export class KeyEventManager implements ComponentEventHandler {
         const [keys, setKeys]  = createStore<Record<string, boolean>>({});
         this._key_state = keys;
         this._set_keys = setKeys;
+
+        const [otherStates, setOtherStates]  = createStore<Record<string, boolean>>({
+            [OtherStates.POINTER_MOVING]: false
+        });
+        this._other_states = otherStates;
+        this._set_other_states = setOtherStates;
 
         const [mouse_button, setMouseButton] = createStore<Record<number, boolean>>({});
         this._mouse_button_state = mouse_button;
@@ -143,8 +178,12 @@ export class KeyEventManager implements ComponentEventHandler {
         this.keybinds = new Map();
     }
 
-    public set_keybind_handler(keybind: Keybind, handler: (data: KeyEventData) => void) {
-        this.keybinds.set(keybind, handler);
+    public set_keybind_handler(keybind: Keybind, handlers: HandlersInterface) {
+        this.keybinds.set(keybind, new KeyHandlers(
+            handlers.just_activated != undefined ? handlers.just_activated : () => {},
+            handlers.while_active != undefined ? handlers.while_active : () => {},
+            handlers.cleanup != undefined ? handlers.cleanup : () => {}
+        ));
     }
 
     public get_keybind_state(keybind_name: string): boolean {
@@ -166,18 +205,36 @@ export class KeyEventManager implements ComponentEventHandler {
         });
     }
 
+    protected update_other_states(event: PointerEvent) {
+        if (event.movementX != 0 || event.movementY != 0) {
+            this._set_other_states(OtherStates.POINTER_MOVING, true)
+        } else {
+            this._set_other_states(OtherStates.POINTER_MOVING, false)
+        }
+    }
+
     protected handle_keybinds(data: KeyEventData) {
         this.keybinds.forEach((handler, keybind) => {
+            const previous_state = keybind.is_active();
             keybind.maps.forEach(map => {
                 map.update_active(
                     this._key_state, 
                     this._mouse_button_state, 
-                    this._modifier_state
+                    this._modifier_state,
+                    this._other_states
                 );
             });
 
-            if (keybind.is_active()) {
-                handler(data);
+            if (!previous_state && keybind.is_active()) {
+                handler.just_activated_handler(data);
+            }
+
+            if (previous_state && keybind.is_active()) {
+                handler.while_active_handler(data);
+            }
+
+            if (previous_state && !keybind.is_active()) {
+                handler.just_deactivated_handler(data);
             }
         });
     }
@@ -203,6 +260,15 @@ export class KeyEventManager implements ComponentEventHandler {
         this.handle_keybinds({event: e})
     }
     
+    onPointerMove(e: PointerEvent): void {
+        this.update_modifier_states(e);
+        // this.update_other_states(e);
+
+        this._set_other_states(OtherStates.POINTER_MOVING, true)
+        this.handle_keybinds({event: e})
+        this._set_other_states(OtherStates.POINTER_MOVING, false)
+    }
+
     onPointerDown(e: PointerEvent): void {
         this.update_modifier_states(e);
         MBUTTON_CODES.forEach(button_code => {

--- a/src/components/editor/input_manager/event-handling.tsx
+++ b/src/components/editor/input_manager/event-handling.tsx
@@ -1,0 +1,34 @@
+import { BaseNode } from "~/components/nodes/base-node";
+import { NodeSlot } from "~/components/nodes/slot/node-slot";
+
+export enum InputEvents {
+    POINTER_MOVING,
+    CLICK_ON_NODE,
+    CLICK_ON_NODE_SLOT,
+    HOVER_NODE,
+    HOVER_SLOT,
+    HOVER_BACKGROUND
+}
+
+export interface EventData {
+    event?: UIEvent
+    node?: BaseNode,
+    slot?: NodeSlot
+}
+
+export interface EventHandlerInterface {
+    handler_func: (event_data: EventData) => void;
+    name: string
+}
+
+export class EventHandler {
+    name: string;
+    private func: (event_data: EventData) => void;
+
+    constructor(handler_name: string, handler_func: (event_data: EventData) => void) {
+        this.name = handler_name;
+        this.func = handler_func;
+    }
+
+    get handler() { return this.func; }
+}

--- a/src/components/editor/input_manager/input-manager.tsx
+++ b/src/components/editor/input_manager/input-manager.tsx
@@ -1,142 +1,11 @@
 import { BaseNode } from "~/components/nodes/base-node";
 import { NodeSlot } from "~/components/nodes/slot/node-slot";
 import { ComponentEventHandler } from "../tools/base-tool";
-import { createSignal } from "solid-js";
 import { createStore, SetStoreFunction } from "solid-js/store";
+import { Keybind, KeyEventData, KeyModifiers, MBUTTON_CODES, MouseButtons } from "./keybind-events";
+import { EventHandler, InputEvents } from "./event-handling";
 
-// TODO: Change this to be an Events enum
-// then create a set_event_handler function on KeyEventManager
-export enum InputEvents {
-    POINTER_MOVING,
-    CLICK_ON_NODE,
-    CLICK_ON_NODE_SLOT,
-    HOVER_NODE,
-    HOVER_SLOT
-}
-
-export enum MouseButtons {
-    NONE = 0,
-    LEFT = 1,
-    RIGHT = 2,
-    MIDDLE = 4,
-    SCROLL
-}
-const MBUTTON_CODES = Object.values(MouseButtons).filter((item): item is number => typeof item === 'number');
-
-export enum KeyModifiers {
-    CTRL,
-    SHIFT,
-    ALT
-}
-
-export interface KeybindMapBinds {
-    mouse_buttons?: MouseButtons[], 
-    keys?: string[], 
-    modifiers?: KeyModifiers[]
-}
-
-export class KeybindMap {
-    private _mouse_buttons: MouseButtons[];
-    private _keys: string[];
-    private _modifiers: KeyModifiers[];
-    private _active: () => boolean;
-    private _set_active: (v: boolean) => void;
-
-    constructor(binds: KeybindMapBinds) {
-        const [active, setActive] = createSignal(false);
-        this._active = active;
-        this._set_active = setActive;
-        
-        this._mouse_buttons = binds.mouse_buttons == null ? [] : binds.mouse_buttons;
-        this._keys = binds.keys == null ? [] : binds.keys;
-        this._modifiers = binds.modifiers == null ? [] : binds.modifiers;
-    }
-
-    get active() { return this._active(); }
-    set active(value: boolean) { this._set_active(value); }
-
-    get mouse_buttons() { return this._mouse_buttons; }
-    get keys() { return this._keys; }
-    get modifiers() { return this._modifiers; }
-
-    public update_active(keys: Record<string, boolean>, mouse_buttons: Record<number, boolean>, modifiers: Record<number, boolean>): boolean {
-        const keys_active = this._keys.length > 0 ? this._keys.every(k => !!keys[k]) : true;
-        const mb_active = this._mouse_buttons.length > 0 ? this._mouse_buttons.every(m => !!mouse_buttons[m]) : true;
-        const mod_active = this._modifiers.length > 0 ? this._modifiers.every(mod => !!modifiers[mod]) : true;
-
-        const has_any_bind = this._keys.length > 0 || this._mouse_buttons.length > 0 || this._modifiers.length > 0;
-        const is_now_active = has_any_bind && keys_active && mb_active && mod_active;
-
-        if (this.active !== is_now_active) {
-            this.active = is_now_active;
-        }
-        return is_now_active;
-    }
-
-    public set_mouse_buttons(buttons: MouseButtons[]) {
-        this._mouse_buttons = buttons;
-    }
-
-    public set_keys(keys: string[]) {
-        this._keys = keys;
-    }
-
-    public set_modifiers(modifiers: KeyModifiers[]) {
-        this._modifiers = modifiers;
-    }
-}
-
-export class Keybind {
-    keybind_name: string;
-    maps: KeybindMap[];
-
-    constructor(name: string, maps: KeybindMap[]) {
-        this.keybind_name = name;
-        this.maps = maps;
-    }
-
-    public add_map(map: KeybindMap) {
-        if (this.maps.includes(map)) {
-            return;
-        }
-        this.maps = [...this.maps, map];
-    }
-
-    public remove_map(map: KeybindMap) {
-        this.maps = this.maps.filter((_map: KeybindMap) => {
-            return _map !== map;
-        })
-    }
-
-    public is_active(): boolean {
-        const active = this.maps.some(map => map.active)
-        return active;
-    }
-}
-
-export interface KeyEventData {
-    event: UIEvent
-}
-
-export interface EventData {
-    event?: UIEvent
-    node?: BaseNode,
-    slot?: NodeSlot
-}
-
-export class EventHandler {
-    name: string;
-    private func: (event_data: EventData) => void;
-
-    constructor(handler_name: string, handler_func: (event_data: EventData) => void) {
-        this.name = handler_name;
-        this.func = handler_func;
-    }
-
-    get handler() { return this.func; }
-}
-
-export interface HandlersInterface {
+export interface KeyHandlersInterface {
     just_activated?: (data: KeyEventData) => void;
     while_active?: (data: KeyEventData) => void;
     cleanup?: (data: KeyEventData) => void;
@@ -196,6 +65,7 @@ export class KeyEventManager implements ComponentEventHandler {
             this.event_handlers.set(key, []);
         });
     }
+   
     
 
     public set_event_handler(target_event: InputEvents, handler: EventHandler) {
@@ -206,7 +76,7 @@ export class KeyEventManager implements ComponentEventHandler {
         event_handlers.push(handler);
     }
 
-    public set_keybind_handler(keybind: Keybind, handlers: HandlersInterface) {
+    public set_keybind_handler(keybind: Keybind, handlers: KeyHandlersInterface) {
         this.keybinds.set(keybind, new KeyHandlers(
             handlers.just_activated != undefined ? handlers.just_activated : () => {},
             handlers.while_active != undefined ? handlers.while_active : () => {},
@@ -284,13 +154,6 @@ export class KeyEventManager implements ComponentEventHandler {
         handlers?.forEach(handler => {
             handler.handler({event: e});
         });
-        // this.update_modifier_states(e);
-
-        // this.update_other_states(e);
-
-        // this._set_other_states(Events.POINTER_MOVING, true)
-        // this.handle_keybinds({event: e})
-        // this._set_other_states(Events.POINTER_MOVING, false)
     }
 
     onPointerDown(e: PointerEvent): void {
@@ -326,9 +189,23 @@ export class KeyEventManager implements ComponentEventHandler {
     }
 
     onHoverNode(node: BaseNode): void {
-        
+        const handlers = this.event_handlers.get(InputEvents.HOVER_NODE)
+        handlers?.forEach(handler => {
+            handler.handler({node: node});
+        });
     }
+
     onHoverSlot(slot: NodeSlot): void {
-        
+        const handlers = this.event_handlers.get(InputEvents.HOVER_SLOT)
+        handlers?.forEach(handler => {
+            handler.handler({slot: slot});
+        });
+    }
+
+    onHoverBackground(): void {
+        const handlers = this.event_handlers.get(InputEvents.HOVER_BACKGROUND)
+        handlers?.forEach(handler => {
+            handler.handler({});
+        });
     }
 }

--- a/src/components/editor/input_manager/input-manager.tsx
+++ b/src/components/editor/input_manager/input-manager.tsx
@@ -1,9 +1,9 @@
 import { BaseNode } from "~/components/nodes/base-node";
 import { NodeSlot } from "~/components/nodes/slot/node-slot";
-import { ComponentEventHandler } from "../tools/base-tool";
+import { BaseEventHandler, ComponentEventHandler } from "../tools/base-tool";
 import { createStore, SetStoreFunction } from "solid-js/store";
 import { Keybind, KeyEventData, KeyModifiers, MBUTTON_CODES, MouseButtons } from "./keybind-events";
-import { EventHandler, InputEvents } from "./event-handling";
+import { EventData, EventHandler, InputEvents } from "./event-handling";
 
 export interface KeyHandlersInterface {
     just_activated?: (data: KeyEventData) => void;
@@ -23,7 +23,7 @@ class KeyHandlers {
     }
 }
 
-export class KeyEventManager implements ComponentEventHandler {
+export class KeyEventManager extends BaseEventHandler {
     keybinds: Map<Keybind, KeyHandlers>;
     event_handlers: Map<InputEvents, Array<EventHandler>>;
     
@@ -37,6 +37,7 @@ export class KeyEventManager implements ComponentEventHandler {
     private _set_modifier: SetStoreFunction<{[key: number]: boolean}>;;
 
     constructor() {
+        super();
         const [keys, setKeys]  = createStore<Record<string, boolean>>({});
         this._key_state = keys;
         this._set_keys = setKeys;
@@ -149,13 +150,6 @@ export class KeyEventManager implements ComponentEventHandler {
         this.handle_keybinds({event: e})
     }
     
-    onPointerMove(e: PointerEvent): void {
-        const handlers = this.event_handlers.get(InputEvents.POINTER_MOVING)
-        handlers?.forEach(handler => {
-            handler.handler({event: e});
-        });
-    }
-
     onPointerDown(e: PointerEvent): void {
         this.update_modifier_states(e);
         MBUTTON_CODES.forEach(button_code => {
@@ -174,38 +168,10 @@ export class KeyEventManager implements ComponentEventHandler {
         this.handle_keybinds({event: e})
     }
 
-    onClickOnNode(node: BaseNode): void {
-        const handlers = this.event_handlers.get(InputEvents.CLICK_ON_NODE)
+    generalizedEventHandler(data: EventData, event_type: InputEvents) {
+        const handlers = this.event_handlers.get(event_type)
         handlers?.forEach(handler => {
-            handler.handler({node: node});
-        });
-    }
-
-    onClickOnNodeSlot(slot: NodeSlot): void {
-        const handlers = this.event_handlers.get(InputEvents.CLICK_ON_NODE_SLOT)
-        handlers?.forEach(handler => {
-            handler.handler({slot: slot});
-        });
-    }
-
-    onHoverNode(node: BaseNode): void {
-        const handlers = this.event_handlers.get(InputEvents.HOVER_NODE)
-        handlers?.forEach(handler => {
-            handler.handler({node: node});
-        });
-    }
-
-    onHoverSlot(slot: NodeSlot): void {
-        const handlers = this.event_handlers.get(InputEvents.HOVER_SLOT)
-        handlers?.forEach(handler => {
-            handler.handler({slot: slot});
-        });
-    }
-
-    onHoverBackground(): void {
-        const handlers = this.event_handlers.get(InputEvents.HOVER_BACKGROUND)
-        handlers?.forEach(handler => {
-            handler.handler({});
+            handler.handler(data);
         });
     }
 }

--- a/src/components/editor/input_manager/keybind-events.tsx
+++ b/src/components/editor/input_manager/keybind-events.tsx
@@ -1,0 +1,106 @@
+import { createSignal } from "solid-js";
+
+export enum MouseButtons {
+    NONE = 0,
+    LEFT = 1,
+    RIGHT = 2,
+    MIDDLE = 4,
+    SCROLL
+}
+export const MBUTTON_CODES = Object.values(MouseButtons).filter((item): item is number => typeof item === 'number');
+
+export enum KeyModifiers {
+    CTRL,
+    SHIFT,
+    ALT
+}
+
+export interface KeybindMapBinds {
+    mouse_buttons?: MouseButtons[], 
+    keys?: string[], 
+    modifiers?: KeyModifiers[]
+}
+
+
+export class KeybindMap {
+    private _mouse_buttons: MouseButtons[];
+    private _keys: string[];
+    private _modifiers: KeyModifiers[];
+    private _active: () => boolean;
+    private _set_active: (v: boolean) => void;
+
+    constructor(binds: KeybindMapBinds) {
+        const [active, setActive] = createSignal(false);
+        this._active = active;
+        this._set_active = setActive;
+        
+        this._mouse_buttons = binds.mouse_buttons == null ? [] : binds.mouse_buttons;
+        this._keys = binds.keys == null ? [] : binds.keys;
+        this._modifiers = binds.modifiers == null ? [] : binds.modifiers;
+    }
+
+    get active() { return this._active(); }
+    set active(value: boolean) { this._set_active(value); }
+
+    get mouse_buttons() { return this._mouse_buttons; }
+    get keys() { return this._keys; }
+    get modifiers() { return this._modifiers; }
+
+    public update_active(keys: Record<string, boolean>, mouse_buttons: Record<number, boolean>, modifiers: Record<number, boolean>): boolean {
+        const keys_active = this._keys.length > 0 ? this._keys.every(k => !!keys[k]) : true;
+        const mb_active = this._mouse_buttons.length > 0 ? this._mouse_buttons.every(m => !!mouse_buttons[m]) : true;
+        const mod_active = this._modifiers.length > 0 ? this._modifiers.every(mod => !!modifiers[mod]) : true;
+
+        const has_any_bind = this._keys.length > 0 || this._mouse_buttons.length > 0 || this._modifiers.length > 0;
+        const is_now_active = has_any_bind && keys_active && mb_active && mod_active;
+
+        if (this.active !== is_now_active) {
+            this.active = is_now_active;
+        }
+        return is_now_active;
+    }
+
+    public set_mouse_buttons(buttons: MouseButtons[]) {
+        this._mouse_buttons = buttons;
+    }
+
+    public set_keys(keys: string[]) {
+        this._keys = keys;
+    }
+
+    public set_modifiers(modifiers: KeyModifiers[]) {
+        this._modifiers = modifiers;
+    }
+}
+
+export class Keybind {
+    keybind_name: string;
+    maps: KeybindMap[];
+
+    constructor(name: string, maps: KeybindMap[]) {
+        this.keybind_name = name;
+        this.maps = maps;
+    }
+
+    public add_map(map: KeybindMap) {
+        if (this.maps.includes(map)) {
+            return;
+        }
+        this.maps = [...this.maps, map];
+    }
+
+    public remove_map(map: KeybindMap) {
+        this.maps = this.maps.filter((_map: KeybindMap) => {
+            return _map !== map;
+        })
+    }
+
+    public is_active(): boolean {
+        const active = this.maps.some(map => map.active)
+        return active;
+    }
+}
+
+export interface KeyEventData {
+    event: UIEvent
+}

--- a/src/components/editor/node-editor.tsx
+++ b/src/components/editor/node-editor.tsx
@@ -9,7 +9,9 @@ import { NodeSlot } from '../nodes/slot/node-slot';
 import { ConnectionController } from './controllers/connection-controller';
 import { ConnectionLines, ConnectionPreview } from '../misc/connection-lines';
 import { Vector2 } from '../../data_types/geometry';
-import { Keybind, KeybindMap, KeyEventManager, MouseButtons, InputEvents, EventHandler } from "./controllers/input-manager";
+import { KeyEventManager as GeneralEventManager } from "./input_manager/input-manager";
+import { Keybind, KeybindMap, MouseButtons } from "./input_manager/keybind-events";
+import { EventHandler, InputEvents } from "./input_manager/event-handling";
 
 export class NodeEditor {
     node_controller: NodeController
@@ -18,13 +20,10 @@ export class NodeEditor {
     selection_controller: SelectionController
     connection_controller: ConnectionController
 
-    input_manager: KeyEventManager
+    input_manager: GeneralEventManager
 
     editor_space: EditorSpace
     editor_grid: Grid
-
-    // _isSpacePressed: () => boolean;
-    // _setSpacePressed: (v: boolean) => void;
 
     _cursor_world_pos: () => Vector2;
     _set_cursor_world_pos: (v: Vector2) => void;
@@ -34,7 +33,7 @@ export class NodeEditor {
         this._cursor_world_pos = cursorWorldPos;
         this._set_cursor_world_pos = setCursorWorldPos;
 
-        this.input_manager = new KeyEventManager();
+        this.input_manager = new GeneralEventManager();
 
         this.node_controller = new NodeController()
         this.editor_space = new EditorSpace()
@@ -137,7 +136,7 @@ export class NodeEditor {
                     this.tool_controller.current_tool?.onClickOnNode(data.node);
                 }
             })
-        )
+        );
 
         this.input_manager.set_event_handler(
             InputEvents.CLICK_ON_NODE_SLOT,
@@ -146,25 +145,33 @@ export class NodeEditor {
                     this.tool_controller.current_tool?.onClickOnNodeSlot(data.slot);
                 }
             })
-        )
+        );
 
         this.input_manager.set_event_handler(
             InputEvents.HOVER_NODE,
             new EventHandler("onHoverNode", (data) => {
                 if (data.node != null) {
+                    console.log("hi")
                     this.tool_controller.current_tool?.onHoverNode(data.node);
                 }
             })
-        )
+        );
 
         this.input_manager.set_event_handler(
-            InputEvents.HOVER_NODE,
+            InputEvents.HOVER_SLOT,
             new EventHandler("onHoverSlot", (data) => {
                 if (data.slot != null) {
                     this.tool_controller.current_tool?.onHoverSlot(data.slot);
                 }
             })
-        )
+        );
+
+        this.input_manager.set_event_handler(
+            InputEvents.HOVER_BACKGROUND,
+            new EventHandler("onHoverBackground", (data) => {
+                this.tool_controller.current_tool?.onHoverBackground();
+            })
+        );
     }
 
     public View() {
@@ -197,7 +204,7 @@ export class NodeEditor {
                     onPointerUp={(e) => this.input_manager.onPointerUp(e)} 
                     onPointerLeave={(e) => this.input_manager.onPointerUp(e)}
                     onMouseOver={() => {
-                        this.tool_controller.current_tool?.onHoverBackground();
+                        this.input_manager.onHoverBackground();
                     }}
                 >
                     <div 

--- a/src/components/editor/node-editor.tsx
+++ b/src/components/editor/node-editor.tsx
@@ -9,7 +9,7 @@ import { NodeSlot } from '../nodes/slot/node-slot';
 import { ConnectionController } from './controllers/connection-controller';
 import { ConnectionLines, ConnectionPreview } from '../misc/connection-lines';
 import { Vector2 } from '../../data_types/geometry';
-import { Keybind, KeybindMap, KeyEventManager, MouseButtons } from "./controllers/input-manager";
+import { Keybind, KeybindMap, KeyEventManager, MouseButtons, OtherStates } from "./controllers/input-manager";
 
 export class NodeEditor {
     node_controller: NodeController
@@ -52,70 +52,83 @@ export class NodeEditor {
 
     public setup_keybinds() {
         this.input_manager.set_keybind_handler(
-            new Keybind("Move", [new KeybindMap({keys: ["Space"]}), new KeybindMap({mouse_buttons: [MouseButtons.MIDDLE]})]),
-            (data) => {
+            new Keybind("PanCamera", [new KeybindMap({keys: ["Space"]}), new KeybindMap({mouse_buttons: [MouseButtons.MIDDLE]})]),
+            {}
+        );
+        this.input_manager.set_keybind_handler(
+            new Keybind("Zoom", [new KeybindMap({mouse_buttons: [MouseButtons.SCROLL]})]),{
+            while_active: (data) => {
+                const e = data.event;
+                if (e instanceof WheelEvent) {
+                    const delta = -e.deltaY * 0.001;
+                    const new_zoom = Math.max(0.1, Math.min(5.0, this.editor_space.camera.zoom + delta));
+                    const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
+                    
+                    this.editor_space.camera.zoom = new_zoom;
+                    this.editor_space.camera.updateOffset({
+                        x: world_pos.x - (screen_pos.x / new_zoom),
+                        y: world_pos.y - (screen_pos.y / new_zoom)
+                    });
+                }
+            }}
+        );
+        this.input_manager.set_keybind_handler(
+            new Keybind("pointerMove", [new KeybindMap({other_states: [OtherStates.POINTER_MOVING]})]),{
+            while_active: (data) => {
+                const e = data.event;
+                if (e instanceof PointerEvent) {
+                    const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
+                    this.cursor_world_pos = world_pos;
+                    if (this.input_manager.get_keybind_state("PanCamera")) {
+                        this.editor_space.camera.move({
+                            x: -e.movementX / this.editor_space.camera.zoom,
+                            y: -e.movementY / this.editor_space.camera.zoom
+                        });
+                        return;
+                    }
 
-            }
-        )
+                    this.tool_controller.current_tool?.onMoveCursor(world_pos, {x: e.movementX, y: e.movementY}, this.node_controller.nodes);
+                }
+            }}
+        );
+
+        this.input_manager.set_keybind_handler(
+            new Keybind("MainToolAction", [new KeybindMap({mouse_buttons: [MouseButtons.LEFT]})]),
+            {just_activated: (data) => {
+                const e = data.event;
+                if (e instanceof PointerEvent) {
+                    const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
+                    if (e.target !== e.currentTarget) return;
+    
+                    this.tool_controller.current_tool?.onPointerDown(e);
+                }
+            },
+            cleanup: (data) => {
+                const e = data.event;
+                if (e instanceof PointerEvent) {
+                    this.tool_controller.current_tool?.onPointerUp(e);
+                    (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+                }
+            }}
+        );
+
+        this.input_manager.set_keybind_handler(
+            new Keybind("SecondaryToolAction", [new KeybindMap({mouse_buttons: [MouseButtons.RIGHT]})]),
+            {just_activated: (data) => {
+                const e = data.event;
+                if (e instanceof PointerEvent) {
+                    const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
+                    if (e.target !== e.currentTarget) return;
+
+                    this.node_controller.add_node("Teste", {x: world_pos.x, y: world_pos.y})
+                }
+            }}
+        );
+        
     }
 
     public View() {
-        
         let viewportRef: HTMLDivElement | undefined;
-        // const onKeyDown = (e: KeyboardEvent) => {
-        //     if (e.code === "Space") this._setSpacePressed(true);
-        // }
-
-        // const onKeyUp = (e: KeyboardEvent) => {
-        //     if (e.code === "Space") this._setSpacePressed(false);
-        // };
-
-        const onWheel = (e: WheelEvent) => {
-            e.preventDefault();
-
-            const delta = -e.deltaY * 0.001;
-            const new_zoom = Math.max(0.1, Math.min(5.0, this.editor_space.camera.zoom + delta));
-            const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
-            
-            this.editor_space.camera.zoom = new_zoom;
-            this.editor_space.camera.updateOffset({
-                x: world_pos.x - (screen_pos.x / new_zoom),
-                y: world_pos.y - (screen_pos.y / new_zoom)
-            });
-        };
-
-        const onPointerDown = (e: PointerEvent) => {
-            const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
-            if (e.target !== e.currentTarget) return;
-
-
-            if (e.button == 2) {
-                this.node_controller.add_node("Teste", {x: world_pos.x, y: world_pos.y})
-            }
-
-            this.tool_controller.current_tool?.onPointerDown(e);
-        }
-        
-        const onPointerMove = (e: PointerEvent) => {
-            const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
-            this.cursor_world_pos = world_pos;
-            if (this.input_manager.get_keybind_state("Move")) {
-                this.editor_space.camera.move({
-                    x: -e.movementX / this.editor_space.camera.zoom,
-                    y: -e.movementY / this.editor_space.camera.zoom
-                });
-                return;
-            }
-            this.tool_controller.current_tool?.onMoveCursor(world_pos, {x: e.movementX, y: e.movementY}, this.node_controller.nodes);
-        };
-
-        const onPointerUp = (e: PointerEvent) => {
-            this.tool_controller.current_tool?.onPointerUp(e);
-
-            (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-        };
-
-        
     
         return (
             <div 
@@ -129,7 +142,7 @@ export class NodeEditor {
                         width: "100%"
                     }}
                     classList={{
-                        'move-mode': this.input_manager.get_keybind_state("Move"),
+                        'move-mode': this.input_manager.get_keybind_state("PanCamera"),
                         'moving-mode': this.selection_controller.moving
                     }}
 
@@ -139,7 +152,7 @@ export class NodeEditor {
                     onKeyUp={(e) => this.input_manager.onKeyUp(e)}
                     onWheel={(e) => this.input_manager.onWheel(e)}
 
-                    onPointerMove={onPointerMove} 
+                    onPointerMove={(e) => this.input_manager.onPointerMove(e)}
                     onPointerDown={(e) => this.input_manager.onPointerDown(e)} 
                     onPointerUp={(e) => this.input_manager.onPointerUp(e)} 
                     onPointerLeave={(e) => this.input_manager.onPointerUp(e)}
@@ -190,6 +203,7 @@ export class NodeEditor {
                             {(node) => {
                                 return (node.View(
                                     this.editor_space.camera, 
+                                    // TODO: Implement these as EventHandlers on InputManager
                                     (node: BaseNode) => {
                                         this.tool_controller.current_tool?.onClickOnNode(node);
                                     },
@@ -208,7 +222,7 @@ export class NodeEditor {
                     </div>
                 </div>
                 
-                <div class="editor-ui">
+                <div class="editor-ui" onPointerMove={(e) => this.input_manager.onPointerMove(e)}>
                     <div class="left-tab">
 
                     </div>

--- a/src/components/editor/node-editor.tsx
+++ b/src/components/editor/node-editor.tsx
@@ -9,6 +9,7 @@ import { NodeSlot } from '../nodes/slot/node-slot';
 import { ConnectionController } from './controllers/connection-controller';
 import { ConnectionLines, ConnectionPreview } from '../misc/connection-lines';
 import { Vector2 } from '../../data_types/geometry';
+import { Keybind, KeybindMap, KeyEventManager, MouseButtons } from "./controllers/input-manager";
 
 export class NodeEditor {
     node_controller: NodeController
@@ -16,6 +17,8 @@ export class NodeEditor {
 
     selection_controller: SelectionController
     connection_controller: ConnectionController
+
+    input_manager: KeyEventManager
 
     editor_space: EditorSpace
     editor_grid: Grid
@@ -30,6 +33,12 @@ export class NodeEditor {
         const [cursorWorldPos, setCursorWorldPos] = createSignal({x: 0, y: 0});
         this._cursor_world_pos = cursorWorldPos;
         this._set_cursor_world_pos = setCursorWorldPos;
+
+        this.input_manager = new KeyEventManager();
+        this.input_manager.set_keybind_handler(
+            new Keybind("Move", [new KeybindMap({keys: ["Space"]}), new KeybindMap({mouse_buttons: [MouseButtons.MIDDLE]})]),
+            (data) => {console.log(data, "move");}
+        )
 
         this.node_controller = new NodeController()
         this.editor_space = new EditorSpace()
@@ -124,14 +133,14 @@ export class NodeEditor {
 
                     oncontextmenu={(e) => {e.preventDefault()}}
                     tabindex="0"
-                    onKeyDown={onKeyDown}
-                    onKeyUp={onKeyUp}
-                    onWheel={onWheel}
+                    onKeyDown={(e) => this.input_manager.onKeyDown(e)}
+                    onKeyUp={(e) => this.input_manager.onKeyUp(e)}
+                    onWheel={(e) => this.input_manager.onWheel(e)}
 
                     onPointerMove={onPointerMove} 
-                    onPointerDown={onPointerDown} 
-                    onPointerUp={onPointerUp} 
-                    onPointerLeave={onPointerUp}
+                    onPointerDown={(e) => this.input_manager.onPointerDown(e)} 
+                    onPointerUp={(e) => this.input_manager.onPointerUp(e)} 
+                    onPointerLeave={(e) => this.input_manager.onPointerUp(e)}
                     onMouseOver={() => {
                         this.tool_controller.current_tool?.onHoverBackground();
                     }}

--- a/src/components/editor/node-editor.tsx
+++ b/src/components/editor/node-editor.tsx
@@ -199,12 +199,12 @@ export class NodeEditor {
                     onKeyUp={(e) => this.input_manager.onKeyUp(e)}
                     onWheel={(e) => this.input_manager.onWheel(e)}
 
-                    onPointerMove={(e) => this.input_manager.onPointerMove(e)}
+                    onPointerMove={(e) => this.input_manager.generalizedEventHandler({event: e}, InputEvents.POINTER_MOVING)}
                     onPointerDown={(e) => this.input_manager.onPointerDown(e)} 
                     onPointerUp={(e) => this.input_manager.onPointerUp(e)} 
                     onPointerLeave={(e) => this.input_manager.onPointerUp(e)}
                     onMouseOver={() => {
-                        this.input_manager.onHoverBackground();
+                        this.input_manager.generalizedEventHandler({}, InputEvents.HOVER_BACKGROUND)
                     }}
                 >
                     <div 
@@ -252,16 +252,16 @@ export class NodeEditor {
                                     this.editor_space.camera, 
                                     // TODO: Implement these as EventHandlers on InputManager
                                     (node: BaseNode) => {
-                                        this.input_manager.onClickOnNode(node);
+                                        this.input_manager.generalizedEventHandler({node: node}, InputEvents.CLICK_ON_NODE)
                                     },
                                     (slot: NodeSlot) => {
-                                        this.input_manager.onClickOnNodeSlot(slot);
+                                        this.input_manager.generalizedEventHandler({slot: slot}, InputEvents.CLICK_ON_NODE_SLOT)
                                     },
                                     (node: BaseNode) => {
-                                        this.input_manager.onHoverNode(node);
+                                        this.input_manager.generalizedEventHandler({node: node}, InputEvents.HOVER_NODE)
                                     },
                                     (slot: NodeSlot) => {
-                                        this.input_manager.onHoverSlot(slot);
+                                        this.input_manager.generalizedEventHandler({slot: slot}, InputEvents.HOVER_SLOT)
                                     })
                                 )
                             }}
@@ -269,7 +269,7 @@ export class NodeEditor {
                     </div>
                 </div>
                 
-                <div class="editor-ui" onPointerMove={(e) => this.input_manager.onPointerMove(e)}>
+                <div class="editor-ui" onPointerMove={(e) => this.input_manager.generalizedEventHandler({event: e}, InputEvents.POINTER_MOVING)}>
                     <div class="left-tab">
 
                     </div>

--- a/src/components/editor/node-editor.tsx
+++ b/src/components/editor/node-editor.tsx
@@ -23,8 +23,8 @@ export class NodeEditor {
     editor_space: EditorSpace
     editor_grid: Grid
 
-    _isSpacePressed: () => boolean;
-    _setSpacePressed: (v: boolean) => void;
+    // _isSpacePressed: () => boolean;
+    // _setSpacePressed: (v: boolean) => void;
 
     _cursor_world_pos: () => Vector2;
     _set_cursor_world_pos: (v: Vector2) => void;
@@ -35,10 +35,6 @@ export class NodeEditor {
         this._set_cursor_world_pos = setCursorWorldPos;
 
         this.input_manager = new KeyEventManager();
-        this.input_manager.set_keybind_handler(
-            new Keybind("Move", [new KeybindMap({keys: ["Space"]}), new KeybindMap({mouse_buttons: [MouseButtons.MIDDLE]})]),
-            (data) => {console.log(data, "move");}
-        )
 
         this.node_controller = new NodeController()
         this.editor_space = new EditorSpace()
@@ -48,25 +44,31 @@ export class NodeEditor {
         this.connection_controller = new ConnectionController();
         
         this.tool_controller = new ToolController(this);
-        
-        const [space, setSpace] = createSignal(false);
-        this._isSpacePressed = space;
-        this._setSpacePressed = setSpace;
+        this.setup_keybinds();
     }
 
     get cursor_world_pos() { return this._cursor_world_pos(); }
     set cursor_world_pos(v: Vector2) { this._set_cursor_world_pos(v); }
 
+    public setup_keybinds() {
+        this.input_manager.set_keybind_handler(
+            new Keybind("Move", [new KeybindMap({keys: ["Space"]}), new KeybindMap({mouse_buttons: [MouseButtons.MIDDLE]})]),
+            (data) => {
+
+            }
+        )
+    }
+
     public View() {
         
         let viewportRef: HTMLDivElement | undefined;
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.code === "Space") this._setSpacePressed(true);
-        }
+        // const onKeyDown = (e: KeyboardEvent) => {
+        //     if (e.code === "Space") this._setSpacePressed(true);
+        // }
 
-        const onKeyUp = (e: KeyboardEvent) => {
-            if (e.code === "Space") this._setSpacePressed(false);
-        };
+        // const onKeyUp = (e: KeyboardEvent) => {
+        //     if (e.code === "Space") this._setSpacePressed(false);
+        // };
 
         const onWheel = (e: WheelEvent) => {
             e.preventDefault();
@@ -97,7 +99,7 @@ export class NodeEditor {
         const onPointerMove = (e: PointerEvent) => {
             const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
             this.cursor_world_pos = world_pos;
-            if (this._isSpacePressed()) {
+            if (this.input_manager.get_keybind_state("Move")) {
                 this.editor_space.camera.move({
                     x: -e.movementX / this.editor_space.camera.zoom,
                     y: -e.movementY / this.editor_space.camera.zoom
@@ -127,7 +129,7 @@ export class NodeEditor {
                         width: "100%"
                     }}
                     classList={{
-                        'move-mode': this._isSpacePressed(),
+                        'move-mode': this.input_manager.get_keybind_state("Move"),
                         'moving-mode': this.selection_controller.moving
                     }}
 

--- a/src/components/editor/node-editor.tsx
+++ b/src/components/editor/node-editor.tsx
@@ -9,7 +9,7 @@ import { NodeSlot } from '../nodes/slot/node-slot';
 import { ConnectionController } from './controllers/connection-controller';
 import { ConnectionLines, ConnectionPreview } from '../misc/connection-lines';
 import { Vector2 } from '../../data_types/geometry';
-import { Keybind, KeybindMap, KeyEventManager, MouseButtons, OtherStates } from "./controllers/input-manager";
+import { Keybind, KeybindMap, KeyEventManager, MouseButtons, InputEvents, EventHandler } from "./controllers/input-manager";
 
 export class NodeEditor {
     node_controller: NodeController
@@ -44,13 +44,14 @@ export class NodeEditor {
         this.connection_controller = new ConnectionController();
         
         this.tool_controller = new ToolController(this);
+        this.setup_event_handlers();
         this.setup_keybinds();
     }
 
     get cursor_world_pos() { return this._cursor_world_pos(); }
     set cursor_world_pos(v: Vector2) { this._set_cursor_world_pos(v); }
 
-    public setup_keybinds() {
+    private setup_keybinds() {
         this.input_manager.set_keybind_handler(
             new Keybind("PanCamera", [new KeybindMap({keys: ["Space"]}), new KeybindMap({mouse_buttons: [MouseButtons.MIDDLE]})]),
             {}
@@ -69,25 +70,6 @@ export class NodeEditor {
                         x: world_pos.x - (screen_pos.x / new_zoom),
                         y: world_pos.y - (screen_pos.y / new_zoom)
                     });
-                }
-            }}
-        );
-        this.input_manager.set_keybind_handler(
-            new Keybind("pointerMove", [new KeybindMap({other_states: [OtherStates.POINTER_MOVING]})]),{
-            while_active: (data) => {
-                const e = data.event;
-                if (e instanceof PointerEvent) {
-                    const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
-                    this.cursor_world_pos = world_pos;
-                    if (this.input_manager.get_keybind_state("PanCamera")) {
-                        this.editor_space.camera.move({
-                            x: -e.movementX / this.editor_space.camera.zoom,
-                            y: -e.movementY / this.editor_space.camera.zoom
-                        });
-                        return;
-                    }
-
-                    this.tool_controller.current_tool?.onMoveCursor(world_pos, {x: e.movementX, y: e.movementY}, this.node_controller.nodes);
                 }
             }}
         );
@@ -125,6 +107,64 @@ export class NodeEditor {
             }}
         );
         
+    }
+
+    private setup_event_handlers() {
+        this.input_manager.set_event_handler(
+            InputEvents.POINTER_MOVING,
+            new EventHandler("onPointerMove", 
+                (data) => {
+                    const e = data.event;
+                    if (e instanceof PointerEvent) {
+                        const [screen_pos, world_pos] = this.editor_space.get_cursor_pos(e)
+                        this.cursor_world_pos = world_pos;
+                        if (this.input_manager.get_keybind_state("PanCamera")) {
+                            this.editor_space.camera.move({
+                                x: -e.movementX / this.editor_space.camera.zoom,
+                                y: -e.movementY / this.editor_space.camera.zoom
+                            });
+                            return;
+                        }
+    
+                        this.tool_controller.current_tool?.onMoveCursor(world_pos, {x: e.movementX, y: e.movementY}, this.node_controller.nodes);
+                    }
+                }
+        ));
+        this.input_manager.set_event_handler(
+            InputEvents.CLICK_ON_NODE,
+            new EventHandler("onClickOnNode", (data) => {
+                if (data.node != null) {
+                    this.tool_controller.current_tool?.onClickOnNode(data.node);
+                }
+            })
+        )
+
+        this.input_manager.set_event_handler(
+            InputEvents.CLICK_ON_NODE_SLOT,
+            new EventHandler("onClickOnSlot", (data) => {
+                if (data.slot != null) {
+                    this.tool_controller.current_tool?.onClickOnNodeSlot(data.slot);
+                }
+            })
+        )
+
+        this.input_manager.set_event_handler(
+            InputEvents.HOVER_NODE,
+            new EventHandler("onHoverNode", (data) => {
+                if (data.node != null) {
+                    this.tool_controller.current_tool?.onHoverNode(data.node);
+                }
+            })
+        )
+
+        this.input_manager.set_event_handler(
+            InputEvents.HOVER_NODE,
+            new EventHandler("onHoverSlot", (data) => {
+                if (data.slot != null) {
+                    this.tool_controller.current_tool?.onHoverSlot(data.slot);
+                }
+            })
+        )
     }
 
     public View() {
@@ -205,16 +245,16 @@ export class NodeEditor {
                                     this.editor_space.camera, 
                                     // TODO: Implement these as EventHandlers on InputManager
                                     (node: BaseNode) => {
-                                        this.tool_controller.current_tool?.onClickOnNode(node);
+                                        this.input_manager.onClickOnNode(node);
                                     },
                                     (slot: NodeSlot) => {
-                                        this.tool_controller.current_tool?.onClickOnNodeSlot(slot);
+                                        this.input_manager.onClickOnNodeSlot(slot);
                                     },
                                     (node: BaseNode) => {
-                                        this.tool_controller.current_tool?.onHoverNode(node);
+                                        this.input_manager.onHoverNode(node);
                                     },
                                     (slot: NodeSlot) => {
-                                        this.tool_controller.current_tool?.onHoverSlot(slot);
+                                        this.input_manager.onHoverSlot(slot);
                                     })
                                 )
                             }}

--- a/src/components/editor/tools/base-tool.tsx
+++ b/src/components/editor/tools/base-tool.tsx
@@ -3,7 +3,7 @@ import { NodeSlot } from "~/components/nodes/slot/node-slot";
 import { Vector2 } from "~/data_types/geometry";
 import { NodeEditor } from "../node-editor";
 
-export interface EditorTool {
+export interface ComponentEventHandler {
     onKeyDown(e: KeyboardEvent): void;
 
     onKeyUp(e: KeyboardEvent): void;
@@ -17,7 +17,9 @@ export interface EditorTool {
     onClickOnNode(node: BaseNode): void;
 
     onClickOnNodeSlot(slot: NodeSlot): void;
+}
 
+export interface EditorTool extends ComponentEventHandler {
     onMoveCursor(pos: Vector2, delta: Vector2, all_nodes: BaseNode[]): void;
 
     onHoverNode(node: BaseNode): void;

--- a/src/components/editor/tools/base-tool.tsx
+++ b/src/components/editor/tools/base-tool.tsx
@@ -10,6 +10,8 @@ export interface ComponentEventHandler {
 
     onWheel(e: WheelEvent): void;
 
+    onPointerMove(e: PointerEvent): void;
+
     onPointerDown(e: PointerEvent): void;
 
     onPointerUp(e: PointerEvent): void;
@@ -41,6 +43,9 @@ export abstract class BaseEditorTool implements EditorTool {
     onKeyUp(e: KeyboardEvent): void {
     }
     onWheel(e: WheelEvent): void {
+    }
+
+    onPointerMove(e: PointerEvent): void {
     }
     onPointerDown(e: PointerEvent): void {
     }

--- a/src/components/editor/tools/base-tool.tsx
+++ b/src/components/editor/tools/base-tool.tsx
@@ -19,17 +19,16 @@ export interface ComponentEventHandler {
     onClickOnNode(node: BaseNode): void;
 
     onClickOnNodeSlot(slot: NodeSlot): void;
-    
+
     onHoverNode(node: BaseNode): void;
     
     onHoverSlot(slot: NodeSlot): void;
+
+    onHoverBackground(): void;
 }
 
 export interface EditorTool extends ComponentEventHandler {
     onMoveCursor(pos: Vector2, delta: Vector2, all_nodes: BaseNode[]): void;
-
-
-    onHoverBackground(): void;
 }
 
 export abstract class BaseEditorTool implements EditorTool {

--- a/src/components/editor/tools/base-tool.tsx
+++ b/src/components/editor/tools/base-tool.tsx
@@ -27,17 +27,7 @@ export interface ComponentEventHandler {
     onHoverBackground(): void;
 }
 
-export interface EditorTool extends ComponentEventHandler {
-    onMoveCursor(pos: Vector2, delta: Vector2, all_nodes: BaseNode[]): void;
-}
-
-export abstract class BaseEditorTool implements EditorTool {
-    node_editor: NodeEditor
-
-    constructor(node_editor: NodeEditor) {
-        this.node_editor = node_editor;
-    }
-
+export abstract class BaseEventHandler implements ComponentEventHandler {
     onKeyDown(e: KeyboardEvent): void {
     }
     onKeyUp(e: KeyboardEvent): void {
@@ -64,5 +54,18 @@ export abstract class BaseEditorTool implements EditorTool {
     onHoverSlot(slot: NodeSlot): void {
     }
     onHoverBackground(): void {
+    }
+}
+
+export interface EditorTool extends ComponentEventHandler {
+    onMoveCursor(pos: Vector2, delta: Vector2, all_nodes: BaseNode[]): void;
+}
+
+export abstract class BaseEditorTool extends BaseEventHandler {
+    node_editor: NodeEditor
+
+    constructor(node_editor: NodeEditor) {
+        super();
+        this.node_editor = node_editor;
     }
 }

--- a/src/components/editor/tools/base-tool.tsx
+++ b/src/components/editor/tools/base-tool.tsx
@@ -19,14 +19,15 @@ export interface ComponentEventHandler {
     onClickOnNode(node: BaseNode): void;
 
     onClickOnNodeSlot(slot: NodeSlot): void;
+    
+    onHoverNode(node: BaseNode): void;
+    
+    onHoverSlot(slot: NodeSlot): void;
 }
 
 export interface EditorTool extends ComponentEventHandler {
     onMoveCursor(pos: Vector2, delta: Vector2, all_nodes: BaseNode[]): void;
 
-    onHoverNode(node: BaseNode): void;
-
-    onHoverSlot(slot: NodeSlot): void;
 
     onHoverBackground(): void;
 }

--- a/src/components/editor/tools/connection-tool.tsx
+++ b/src/components/editor/tools/connection-tool.tsx
@@ -1,6 +1,5 @@
 import { BaseNode } from '~/components/nodes/base-node';
-import { Vector2 } from '~/data_types/geometry';
-import { BaseEditorTool, EditorTool } from './base-tool';
+import { BaseEditorTool } from './base-tool';
 import { NodeSlot } from '~/components/nodes/slot/node-slot';
 import { ConnectionController } from '../controllers/connection-controller';
 import { NodeEditor } from '../node-editor';

--- a/src/components/editor/tools/selection-tool.tsx
+++ b/src/components/editor/tools/selection-tool.tsx
@@ -25,7 +25,6 @@ export class SelectionTool extends BaseEditorTool {
 
     onPointerDown(e: PointerEvent): void {
         const [screen_pos, world_pos] = this.selection_controller.editor_space.get_cursor_pos(e)
-
         if (e.button == 0) {
             if (this.selection_controller.has_selected) {
                 this.selection_controller.clearSelection();
@@ -35,10 +34,6 @@ export class SelectionTool extends BaseEditorTool {
             (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
             this.selection_controller.onStartAreaSelection({x: world_pos.x, y: world_pos.y});
         }
-
-        // if (e.button == 2) {
-        //     this.node_controller.add_node("Teste", {x: world_pos.x, y: world_pos.y})
-        // } 
     }
 
     onPointerUp(e: PointerEvent): void {

--- a/src/components/nodes/base-node.tsx
+++ b/src/components/nodes/base-node.tsx
@@ -33,7 +33,6 @@ export class BaseNode {
         this.node_name = node_name;
         this.raw_pos = position;
 
-        console.log(node_data)
         const [nodeData, setNodeData] = createSignal(node_data);
         this._node_data = nodeData;
         this._set_node_data = setNodeData;
@@ -55,7 +54,7 @@ export class BaseNode {
     }
 
     get node_data() { return this._node_data(); }
-    set node_data(data: NodeData) { this._set_node_data(data); console.log(data); }
+    set node_data(data: NodeData) { this._set_node_data(data); }
     
     get pos() { return this._pos() }
     get x() { return this.pos.x }
@@ -190,7 +189,8 @@ export class BaseNode {
                         class="internal-node"
                         data-node-id={this.id}
                         onPointerDown={(e) => {
-                            e.stopPropagation();
+                            // FIXME: Stop Propagation shouldn't break PointerDown Cleanup
+                            // e.stopPropagation();
                             (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
                             onClick(this);
                         }}


### PR DESCRIPTION
Stop using constant event handlers on Node Editor Element body and use Event Handlers so the Input Manager can call keybind handler functions and event handlers without needing to change Node Editor at all.